### PR TITLE
NOISSUE remove extant error log, blacklist .log files in .gitignore, …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '16' }} # Only upload artifacts built from LTS java on one OS
+        if: ${{ matrix.java == '16' }} 
         uses: actions/upload-artifact@v2
         with:
-          name: Artifacts
+          name: Artifacts-${{ matrix.os }}
           path: build/libs/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ bin/
 # fabric
 
 run/
+
+# random log files
+*.log


### PR DESCRIPTION
…and have both OS' upload artifacts.

PRIOR TO EDIT:

…and have CI only compile on Ubuntu 20.04, as there's no reason to compile on two OS' when it comes to Java, especially if you're only uploading artifacts from one of them.
